### PR TITLE
Exits when negative drink credits

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -91,6 +91,7 @@ func (r PlugRoutes) upload(c *gin.Context) {
 		if numCredits < 0 {
 			log.Error(err)
 			c.String(http.StatusBadRequest, "Can't specify negative credits!")
+			return
 		}
 		mime := getMime(data)
 		data.Seek(0, 0)


### PR DESCRIPTION
Previously if you put a negative number into the payment for a plug it would add the drink credits to the users account. Now it will not.